### PR TITLE
fix argv bug when argc == 1

### DIFF
--- a/buaa_login.py
+++ b/buaa_login.py
@@ -83,7 +83,7 @@ def get_info():
 
 
 def main():
-    option = sys.argv[1]
+    option = sys.argv[min(len(sys.argv) - 1,1)]
     if option == "login":
         login()
     elif option == "logout":


### PR DESCRIPTION
未输入命令行参数时程序将崩溃，修复后能正常弹出提示